### PR TITLE
002: 回転時にテトリミノが崩れる問題の修正

### DIFF
--- a/tetris/main.html
+++ b/tetris/main.html
@@ -142,20 +142,34 @@
         // テトリミノの回転（修正版）
         function rotate(piece) {
             const temp = piece.shape.map((_, i) => piece.shape.map(row => row[i]).reverse());
+
+            // 特殊なテトリミノ（I型など）を正しく回転させるための処理
+            if (piece.shape.length === 4) { 
+                // I型テトリミノの場合は、さらに調整を加える
+                const temp2 = [
+                    [piece.shape[3][0], piece.shape[2][0], piece.shape[1][0], piece.shape[0][0]],
+                    [piece.shape[3][1], piece.shape[2][1], piece.shape[1][1], piece.shape[0][1]],
+                    [piece.shape[3][2], piece.shape[2][2], piece.shape[1][2], piece.shape[0][2]],
+                    [piece.shape[3][3], piece.shape[2][3], piece.shape[1][3], piece.shape[0][3]]
+                ];
+                piece.shape = temp2;
+            } else {
+                piece.shape = temp;
+            }
+
             const posX = piece.pos.x;
             let offset = 1;
 
             // 回転後の形状が衝突していないか確認
-            while (collide(board, { shape: temp, pos: { x: piece.pos.x, y: piece.pos.y } })) {
+            while (collide(board, piece)) {
                 piece.pos.x += offset;
                 offset = -(offset + (offset > 0 ? 1 : -1));
                 if (offset > piece.shape[0].length) {
-                    return; // 回転できない場合はそのまま
+                    piece.shape = temp; // 回転を元に戻す
+                    piece.pos.x = posX; // 位置も元に戻す
+                    return;
                 }
             }
-
-            piece.shape = temp;
-            piece.pos.x = posX; // 位置を元に戻す
         }
 
         // テトリミノの落下

--- a/tetris/main.html
+++ b/tetris/main.html
@@ -139,37 +139,15 @@
             drawPiece(piece);
         }
 
-        // テトリミノの回転（修正版）
-        function rotate(piece) {
-            const temp = piece.shape.map((_, i) => piece.shape.map(row => row[i]).reverse());
-
-            // 特殊なテトリミノ（I型など）を正しく回転させるための処理
-            if (piece.shape.length === 4) { 
-                // I型テトリミノの場合は、さらに調整を加える
-                const temp2 = [
-                    [piece.shape[3][0], piece.shape[2][0], piece.shape[1][0], piece.shape[0][0]],
-                    [piece.shape[3][1], piece.shape[2][1], piece.shape[1][1], piece.shape[0][1]],
-                    [piece.shape[3][2], piece.shape[2][2], piece.shape[1][2], piece.shape[0][2]],
-                    [piece.shape[3][3], piece.shape[2][3], piece.shape[1][3], piece.shape[0][3]]
-                ];
-                piece.shape = temp2;
-            } else {
-                piece.shape = temp;
+        // 回転関数（回転回数を指定してテトリミノの形状を回転）
+        function rotateMatrix(matrix, times) {
+            let rotatedMatrix = matrix;
+            for (let i = 0; i < times; i++) {
+                rotatedMatrix = rotatedMatrix[0].map((_, index) =>
+                    rotatedMatrix.map(row => row[index]).reverse()
+                );
             }
-
-            const posX = piece.pos.x;
-            let offset = 1;
-
-            // 回転後の形状が衝突していないか確認
-            while (collide(board, piece)) {
-                piece.pos.x += offset;
-                offset = -(offset + (offset > 0 ? 1 : -1));
-                if (offset > piece.shape[0].length) {
-                    piece.shape = temp; // 回転を元に戻す
-                    piece.pos.x = posX; // 位置も元に戻す
-                    return;
-                }
-            }
+            return rotatedMatrix;
         }
 
         // テトリミノの落下
@@ -207,7 +185,10 @@
             } else if (event.key === 'ArrowDown') {
                 drop();
             } else if (event.key === 'ArrowUp') {
-                rotate(piece);
+                piece.shape = rotateMatrix(piece.shape, 1); // 1回回転
+                if (collide(board, piece)) {
+                    piece.shape = rotateMatrix(piece.shape, 3); // 回転を元に戻す
+                }
             }
             draw();
         });

--- a/tetris/main.html
+++ b/tetris/main.html
@@ -139,21 +139,23 @@
             drawPiece(piece);
         }
 
-        // テトリミノの回転
+        // テトリミノの回転（修正版）
         function rotate(piece) {
             const temp = piece.shape.map((_, i) => piece.shape.map(row => row[i]).reverse());
-            const pos = piece.pos.x;
+            const posX = piece.pos.x;
             let offset = 1;
-            while (collide(board, { shape: temp, pos: piece.pos })) {
+
+            // 回転後の形状が衝突していないか確認
+            while (collide(board, { shape: temp, pos: { x: piece.pos.x, y: piece.pos.y } })) {
                 piece.pos.x += offset;
                 offset = -(offset + (offset > 0 ? 1 : -1));
                 if (offset > piece.shape[0].length) {
-                    piece.shape = temp;
-                    piece.pos.x = pos;
-                    return;
+                    return; // 回転できない場合はそのまま
                 }
             }
+
             piece.shape = temp;
+            piece.pos.x = posX; // 位置を元に戻す
         }
 
         // テトリミノの落下


### PR DESCRIPTION
>  動かしてみました。テトリミノを回転させると形が崩れてしまいます。修正をお願いします。


テトリミノの回転が崩れる原因として、回転処理の行列変換部分に問題がある可能性があります。回転時に衝突判定を追加し、回転が不正な位置で行われないよう調整してみましょう。

変更点
rotate関数: 回転時の形状がボードの端や他のブロックと衝突しないか確認するために、衝突した際には位置を調整して回転を試みるようにしました。